### PR TITLE
lcdexec-setup fixes

### DIFF
--- a/clients/lcdexec/lcdexec-setup
+++ b/clients/lcdexec/lcdexec-setup
@@ -209,7 +209,7 @@ kdb_set() {
 }
 
 kdb_setmeta() {
-    run_kdb setmeta "$NAMESPACE$BASE_KEY/$1" "$2" "$3"
+    run_kdb meta-set "$NAMESPACE$BASE_KEY/$1" "$2" "$3"
 }
 
 kdb_rm_r() {
@@ -221,7 +221,7 @@ kdb_exists() {
 }
 
 kdb_array_last() {
-    kdb getmeta "$BASE_KEY/$1" array 2>/dev/null
+    kdb meta-get "$BASE_KEY/$1" array 2>/dev/null
 }
 
 kdb_export() {

--- a/docs/elektra/README.md
+++ b/docs/elektra/README.md
@@ -2,7 +2,7 @@
 
 ## Setting up Elektra
 
--   Checkout the latest version of Elektra's `master` branch (commit `79408a3509d4e8f97369c877ff08709f7de04976`
+-   Checkout the latest version of Elektra's `master` branch (commit `704812a1841a02cbb4be06256cbc03d9342d841d`
     or later).
 -   Compile Elektra
     ```sh


### PR DESCRIPTION
Fixes #10
Changed two occurences of the old get/set meta commands in `lcdexec-setup`.
Updated  oldest usable elektra commit in `elektra/README.md` to reflect changes.